### PR TITLE
fix for nt/#3-fix-CF-to-use-S3-bucket-parameter

### DIFF
--- a/07_Resources/S3/_index.json
+++ b/07_Resources/S3/_index.json
@@ -2,7 +2,7 @@
 	"S3Bucket": {
 		"Type": "AWS::S3::Bucket",
 		"Properties": {
-			"BucketName": { "Fn::Sub": "0x4447-rsyslog-${AWS::Region}-${UniqueIdentifierParam}" },
+			"BucketName": { "Fn::Sub": "${S3BucketParam}" },
 			"PublicAccessBlockConfiguration": {
 				"BlockPublicAcls": true,
 				"BlockPublicPolicy": true,


### PR DESCRIPTION
Fixed S3Bucket to use the S3BucketParam from CF Parameters. Verified that the S3 bucket was created and consists of two folders, certs and bash. The client-setup.sh script is under bash.

